### PR TITLE
chore: add release-please workflow + fix config for STLC cutover

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,216 @@
+name: Release Please
+
+# Self-hosted release-please for team-telnyx/telnyx-go.
+#
+# Two-phase trigger:
+#   1. Push to `next` → create/update release PR targeting `main`
+#   2. Push to `main` (release PR merged) → create GitHub release + tag
+#
+# The promote-to-prod workflow pushes generated SDK code to the `next` branch
+# with a `Release-As: X.Y.Z` footer. This workflow runs release-please when
+# `next` receives new commits, which:
+#   1. Reads the Release-As version from the commit footer
+#   2. Opens a release PR targeting `main` with --release-as
+#   3. Merges `next` into the release PR branch so code changes are included
+#   4. On merge, push to `main` triggers this workflow again
+#   5. github-release creates vX.Y.Z tag and GitHub Release
+#   6. The Go module proxy (proxy.golang.org) picks up the tag automatically
+#      → `go get github.com/team-telnyx/telnyx-go/v4@vX.Y.Z` works immediately
+#
+# Go does NOT need a separate publish workflow — Git tags ARE the release.
+#
+# Uses the official Google release-please from npm (not the Stainless fork,
+# which has broken TypeScript compilation on newer Node versions).
+
+on:
+  push:
+    branches:
+      - next      # Phase 1: create release PR
+      - main      # Phase 2: create GitHub release + tag
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    if: github.repository == 'team-telnyx/telnyx-go'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SDK_WRITE_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install release-please
+        run: npm install --no-save release-please@17
+
+      - name: Read Release-As version from next branch
+        if: github.ref == 'refs/heads/next'
+        id: version
+        run: |
+          VERSION=""
+          # The promote-to-prod workflow injects a "Release-As: X.Y.Z" footer
+          # into the promote commit. Find the latest one in next history.
+          for commit in $(git rev-list HEAD --max-count=50); do
+            BODY=$(git log -1 --format=%b "$commit")
+            RA=$(echo "$BODY" | grep -oP 'Release-As:\s*\K[\d.]+' || true)
+            if [ -n "$RA" ]; then
+              VERSION="$RA"
+              break
+            fi
+          done
+
+          if [ -z "$VERSION" ]; then
+            echo "::warning::No Release-As found; release-please will use semantic versioning"
+            echo "has_version=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "has_version=true" >> "$GITHUB_OUTPUT"
+            echo "Release-As version: $VERSION"
+          fi
+
+      - name: Run release-please (release-pr)
+        if: github.ref == 'refs/heads/next'
+        id: release-pr
+        run: |
+          ARGS=(
+            release-pr
+            --repo-url "${{ github.repositoryUrl }}"
+            --token "${{ secrets.SDK_WRITE_TOKEN }}"
+            --target-branch main
+            --config-file release-please-config.json
+            --manifest-file .release-please-manifest.json
+            --local
+          )
+
+          if [ "${{ steps.version.outputs.has_version }}" = "true" ]; then
+            ARGS+=(--release-as "${{ steps.version.outputs.version }}")
+          fi
+
+          OUTPUT=$(npx release-please "${ARGS[@]}" 2>&1) || true
+          echo "$OUTPUT"
+
+          # Parse PR number from output if a PR was created
+          PR_URL=$(echo "$OUTPUT" | grep -oP 'https://github\.com/[^/]+/[^/]+/pull/\d+' | head -1)
+          if [ -n "$PR_URL" ]; then
+            PR_NUM=$(echo "$PR_URL" | grep -oP '\d+$')
+            echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
+            echo "prs_created=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prs_created=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Merge next code into release PR
+        if: github.ref == 'refs/heads/next'
+        env:
+          GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
+        run: |
+          # release-please creates a PR with only version bumps (CHANGELOG,
+          # internal/version.go, README, etc). The actual SDK code changes are
+          # on `next` but NOT included in the release PR. This step merges
+          # `next` into the release PR branch so the PR carries both code
+          # and version bumps to main.
+          #
+          # Without this, main gets version bumps only — the published
+          # Go module has the new version number but old code.
+
+          # Use the PR number from the release-please step directly (avoids
+          # GitHub API eventual-consistency race where gh pr list doesn't see
+          # a PR that was created milliseconds ago).
+          PR_BRANCH=""
+          if [ -n "$PR_NUM" ]; then
+            sleep 3  # brief propagation delay
+            PR_BRANCH=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+          fi
+
+          # Fallback: query by label with retry
+          if [ -z "$PR_BRANCH" ]; then
+            for i in 1 2 3; do
+              PR_BRANCH=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json headRefName --jq '.[0].headRefName' 2>/dev/null || true)
+              if [ -n "$PR_BRANCH" ]; then break; fi
+              echo "PR not found yet, retrying in 5s (attempt $i)..."
+              sleep 5
+            done
+          fi
+
+          if [ -z "$PR_BRANCH" ]; then
+            echo "::warning::No open release PR found after retries, skipping merge"
+            exit 0
+          fi
+
+          echo "Found release PR branch: $PR_BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "$PR_BRANCH" next
+          git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
+
+          # -X ours: on conflicts, prefer the release-please branch's version
+          # bumps (canonical version + changelog). Non-conflicting code changes
+          # from next are included normally.
+          if git merge origin/next --no-edit -X ours; then
+            git push origin "$PR_BRANCH"
+            echo "Successfully merged next into release PR branch"
+          else
+            # Handle modify/delete conflicts: prod-owned files (like
+            # .release-please-manifest.json) may be deleted on `next` (staging
+            # doesn't have them) but modified on the release PR branch.
+            # Resolution: keep the release PR branch's version (--ours).
+            CONFLICTS=$(git diff --name-only --diff-filter=U)
+            if [ -n "$CONFLICTS" ]; then
+              echo "Resolving modify/delete conflicts:"
+              echo "$CONFLICTS"
+              # For all conflicted files, keep our version (release PR branch)
+              echo "$CONFLICTS" | while IFS= read -r f; do
+                git checkout --ours "$f" 2>/dev/null || true
+                git add "$f" 2>/dev/null || true
+              done
+              git commit --no-edit
+              git push origin "$PR_BRANCH"
+              echo "Successfully merged next into release PR branch (with conflict resolution)"
+            else
+              echo "::error::Failed to merge next into release PR"
+              git merge --abort
+              exit 1
+            fi
+          fi
+
+      - name: Run release-please (github-release)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          npx release-please github-release \
+            --repo-url "${{ github.repositoryUrl }}" \
+            --token "${{ secrets.SDK_WRITE_TOKEN }}" \
+            --target-branch main \
+            --config-file release-please-config.json \
+            --manifest-file .release-please-manifest.json \
+            2>&1
+
+      - name: Enable auto-merge on release PRs
+        if: github.ref == 'refs/heads/next' && steps.release-pr.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
+        run: |
+          if [ -n "$PR_NUM" ]; then
+            gh pr merge "$PR_NUM" --auto --merge --repo "$REPO" 2>/dev/null || echo "Auto-merge already enabled or PR #$PR_NUM not mergeable"
+          fi
+          sleep 3
+          # Fallback: enable auto-merge on any open release PRs
+          prs=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json number --jq '.[].number')
+          for pr in $prs; do
+            gh pr merge "$pr" --auto --merge --repo "$REPO" 2>/dev/null || true
+          done

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,11 +2,9 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
-  "versioning": "prerelease",
-  "prerelease": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "pull-request-header": "Automated Release PR",


### PR DESCRIPTION
## What

### 1. Adds `release-please.yml` (new)
Two-phase self-hosted release-please using CLI `release-please@17`:

**Phase 1** (push to `next`):
- Reads `Release-As: X.Y.Z` footer from promote-to-prod commit
- Creates release PR targeting `main` with version bump
- Merges `next` code into the release PR branch (code + version bumps together)
- Enables auto-merge

**Phase 2** (push to `main`):
- Creates `vX.Y.Z` Git tag + GitHub Release
- Go module proxy (`proxy.golang.org`) picks up tag → `go get github.com/team-telnyx/telnyx-go/v4@vX.Y.Z` works

### 2. Fixes `release-please-config.json`
| Change | Before | After |
|--------|--------|-------|
| `prerelease` | `true` | **removed** (Go is v4.x, not prerelease) |
| `versioning` | `prerelease` | **removed** |
| `` | Stainless fork URL | Official Google URL |
| `extra-files` | included `create-releases.yml` | Removed (file doesn't exist) |

### Pipeline
```
stlc-generate → staging main → promote-to-prod → prod next → [this workflow] → prod main → tag (publish)
```

### Depends on
- `SDK_WRITE_TOKEN` secret on this repo (Ankit to add)
- `promote-to-prod.yml` PR on staging: https://github.com/team-telnyx/telnyx-go-staging/pull/117

### Reference
Modeled on `telnyx-ruby` and `telnyx-node` prod release-please workflows.
Target branch: `main` (Go default branch, unlike Ruby/Node which use `master`).