### PR TITLE
fix(release): keep release PR history on production base

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -73,19 +73,36 @@ jobs:
             ARGS+=(--release-as "${{ steps.version.outputs.version }}")
           fi
 
-          # Widen the --local commit scan to next's promote commits: release-pr
-          # collects commits since the last release on the TARGET branch (main),
-          # so with only hidden ci:-typed commits on main it silently skips
-          # (releases previously depended on coincidental fix-typed hotfixes).
-          # next always contains main (the promote enforces ancestry), so
-          # pointing the local refs at HEAD only widens the scan; the PR is
-          # still created against main via the API.
-          git branch -f main HEAD 2>/dev/null || true
-          git update-ref refs/remotes/origin/main HEAD
-          # --local mode normalizes --repo-url to HTTPS before cloning. Rewrite
-          # that normalized URL to this workspace so the clone sees the
-          # repointed target branch above instead of the quiet remote branch.
-          # Keep --repo-url unchanged so API PR creation still parses owner/repo.
+          # Build a one-commit local scan ref on the real production base. `next`
+          # accumulates promote commits because release PRs are squash-merged; scanning
+          # it directly makes old commits reappear and starts CHANGELOG from staging's
+          # stale copy. The synthetic commit keeps next's code tree, restores release
+          # metadata from the production base, and has exactly one parent: that base.
+          BASE_BRANCH="${{ github.event.repository.default_branch }}"
+          git fetch origin "$BASE_BRANCH:refs/remotes/origin/release-base" next
+          RELEASE_BASE=$(git rev-parse refs/remotes/origin/release-base)
+          RELEASE_FILES=("CHANGELOG.md" "internal/version.go" "README.md" ".github/workflows/create-releases.yml" ".release-please-manifest.json")
+          git restore --source=refs/remotes/origin/release-base --staged --worktree -- "${RELEASE_FILES[@]}"
+          SCAN_TREE=$(git write-tree)
+          PROMOTE_SUBJECT=$(git log --format=%s --max-count=50 HEAD \
+            | grep -m1 -E '^(feat|fix|chore)(\([^)]*\))?!?: promote from staging ' || true)
+          if [ -z "$PROMOTE_SUBJECT" ]; then
+            PROMOTE_SUBJECT="feat: promote generated SDK changes"
+          fi
+          if [ "${{ steps.version.outputs.has_version }}" = "true" ]; then
+            SCAN_COMMIT=$(printf '%s\n\nRelease-As: %s\n' \
+              "$PROMOTE_SUBJECT" "${{ steps.version.outputs.version }}" \
+              | git commit-tree "$SCAN_TREE" -p "$RELEASE_BASE")
+          else
+            SCAN_COMMIT=$(printf '%s\n' "$PROMOTE_SUBJECT" \
+              | git commit-tree "$SCAN_TREE" -p "$RELEASE_BASE")
+          fi
+          git branch -f "$BASE_BRANCH" "$SCAN_COMMIT"
+          git update-ref "refs/remotes/origin/$BASE_BRANCH" "$SCAN_COMMIT"
+
+          # --local normalizes --repo-url to HTTPS before cloning. Rewrite that URL
+          # to this workspace so release-please sees the synthetic scan ref while
+          # API operations still target the real repository.
           git config --global protocol.file.allow always
           git config --global url."file://${GITHUB_WORKSPACE}".insteadOf "https://github.com/${{ github.repository }}.git"
 
@@ -134,7 +151,7 @@ jobs:
           # The actual SDK code changes are on `next` but NOT included in the
           # release PR. This step syncs `next` code into the release PR branch.
           #
-          # CRITICAL: We use tree replacement (checkout + restore version files)
+          # CRITICAL: We use tree replacement on a clean production base
           # instead of git merge. A 3-way merge produces duplicate method
           # implementations when staging and prod have different method ordering
           # (git sees them as non-conflicting additions and keeps both copies).
@@ -167,7 +184,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git fetch origin "$PR_BRANCH" next
+          BASE_BRANCH="${{ github.event.repository.default_branch }}"
+          git fetch origin "$PR_BRANCH" next "$BASE_BRANCH:refs/remotes/origin/release-base"
           git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
 
           # Save version-bump files from the release PR branch (release-please output)
@@ -179,10 +197,12 @@ jobs:
             fi
           done
 
-          # Replace entire working tree from next (exact tree, no merge)
-          # git rm handles deletions (files removed in next but still in this branch)
-          # git clean removes untracked files (node_modules created by npx release-please)
-          git reset --hard origin/next
+          # Rebase the release branch onto the real production base, then replace
+          # only its index/worktree with next's exact tree. `git read-tree` preserves
+          # clean master ancestry while still handling additions and deletions
+          # atomically (unlike the old `git reset --hard origin/next`).
+          git checkout -B "$PR_BRANCH" refs/remotes/origin/release-base
+          git read-tree --reset -u origin/next
           git clean -fdx
 
           # Restore version-bump files from the release PR branch
@@ -200,8 +220,23 @@ jobs:
             echo "No changes after syncing next code"
           else
             git commit -m "chore: sync code from next into release PR"
+
+            # Regression guards: the PR must be exactly one commit on the real base,
+            # and every previously released CHANGELOG section must still exist.
+            COMMIT_COUNT=$(git rev-list --count refs/remotes/origin/release-base..HEAD)
+            if [ "$COMMIT_COUNT" -ne 1 ]; then
+              echo "::error::Release PR has $COMMIT_COUNT commits above production base; expected exactly 1"
+              exit 1
+            fi
+            while IFS= read -r heading; do
+              if ! grep -Fqx -- "$heading" CHANGELOG.md; then
+                echo "::error::Release PR dropped existing CHANGELOG section: $heading"
+                exit 1
+              fi
+            done < <(git show refs/remotes/origin/release-base:CHANGELOG.md | grep '^## ' || true)
+
             git push --force origin "$PR_BRANCH"
-            echo "Successfully synced next code into release PR branch (tree replacement)"
+            echo "Successfully synced next code into a clean production-based release PR"
           fi
       - name: Assert release PR exists for unreleased commits (fail loud)
         if: github.ref == 'refs/heads/next'


### PR DESCRIPTION
## Summary
- scan a synthetic one-commit view of `next` based on the real production branch
- preserve production release metadata and changelog history
- sync the generated SDK tree without inheriting `next` commit ancestry
- fail before push unless the release PR is exactly one commit above production and retains every existing changelog section

## Root cause
The release sync used `git reset --hard origin/next` before force-pushing the release branch. Since release PRs are squash-merged, old promotion SHAs remain unique to `next`; every new release PR therefore inherited all historical promotion commits. The stale staging changelog was also used as the release base, deleting already-published sections.

## Validation
- `git diff --check`
- `actionlint -ignore SC2034 .github/workflows/release-please.yml`
- local Python release-please v17 dry run against a synthetic scan ref produced one promotion entry and retained the production changelog
