### PR TITLE
fix(release): handle checkout and obsolete release path

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -86,7 +86,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          RELEASE_FILES=("CHANGELOG.md" "internal/version.go" "README.md" ".github/workflows/create-releases.yml" ".release-please-manifest.json")
+          RELEASE_FILES=("CHANGELOG.md" "internal/version.go" "README.md" ".release-please-manifest.json")
           git restore --source=refs/remotes/origin/release-base --staged --worktree -- "${RELEASE_FILES[@]}"
           SCAN_TREE=$(git write-tree)
           PROMOTE_SUBJECT=$(git log --format=%s --max-count=50 HEAD \
@@ -152,7 +152,7 @@ jobs:
           PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
         run: |
           # release-please creates a PR with only version bumps (CHANGELOG,
-          # version.go, README, create-releases.yml, CHANGELOG.md, .release-please-manifest.json).
+          # version.go, README, CHANGELOG.md, .release-please-manifest.json).
           # The actual SDK code changes are on `next` but NOT included in the
           # release PR. This step syncs `next` code into the release PR branch.
           #
@@ -189,11 +189,11 @@ jobs:
 
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$PR_BRANCH" next "$BASE_BRANCH:refs/remotes/origin/release-base"
-          git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
+          git checkout -f -B "$PR_BRANCH" "origin/$PR_BRANCH"
 
           # Save version-bump files from the release PR branch (release-please output)
           STASH_DIR=$(mktemp -d)
-          for f in CHANGELOG.md internal/version.go README.md .github/workflows/create-releases.yml .release-please-manifest.json; do
+          for f in CHANGELOG.md internal/version.go README.md .release-please-manifest.json; do
             if [ -f "$f" ]; then
               mkdir -p "$STASH_DIR/$(dirname "$f")"
               cp "$f" "$STASH_DIR/$f"
@@ -209,7 +209,7 @@ jobs:
           git clean -fdx
 
           # Restore version-bump files from the release PR branch
-          for f in CHANGELOG.md internal/version.go README.md .github/workflows/create-releases.yml .release-please-manifest.json; do
+          for f in CHANGELOG.md internal/version.go README.md .release-please-manifest.json; do
             if [ -f "$STASH_DIR/$f" ]; then
               mkdir -p "$(dirname "$f")"
               cp "$STASH_DIR/$f" "$f"


### PR DESCRIPTION
## Summary\n- force-discard temporary caller-worktree changes left by `release-please --local` before checking out the authoritative remote release branch\n- remove obsolete `.github/workflows/create-releases.yml` release-file handling\n\n## Root cause\nThe workflow failed before release PR creation because it unconditionally restored `.github/workflows/create-releases.yml`, which is absent from the production base. After release PR creation, the same dirty caller-worktree checkout issue affects Go as the other SDKs.\n\n## Validation\n- `git diff --check`\n- `actionlint -ignore SC2034 .github/workflows/release-please.yml`\n