### PR TITLE
fix(ci): validate Go release candidates

### DIFF
--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -381,6 +381,10 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertIn(
             "startsWith(github.event.pull_request.title, 'release: ')", workflow
         )
+        self.assertIn("github.event.pull_request.state == 'open'", workflow)
+        self.assertIn(
+            "github.event.label.name == 'autorelease: pending'", workflow
+        )
 
     def test_merge_uses_immediate_rest_put_and_never_enables_auto_merge(self):
         client = GitHubClient(GateConfig.python(), "test-token")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,12 @@ jobs:
       id-token: write
     runs-on: ${{ github.repository == 'stainless-sdks/telnyx-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: |-
-      github.repository == 'stainless-sdks/telnyx-go' &&
-      (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+      (github.repository == 'stainless-sdks/telnyx-go' &&
+       (github.event_name == 'push' || github.event.pull_request.head.repo.fork) &&
+       (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')) ||
+      (github.repository == 'team-telnyx/telnyx-go' &&
+       github.event_name == 'pull_request' &&
+       startsWith(github.head_ref, 'release-please--'))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -46,6 +50,16 @@ jobs:
           AUTH: ${{ steps.github-oidc.outputs.github_token }}
           SHA: ${{ github.sha }}
         run: ./scripts/utils/upload-artifact.sh
+
+      - name: Setup Go for release verification
+        if: github.repository == 'team-telnyx/telnyx-go'
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: ./go.mod
+
+      - name: Build release candidate
+        if: github.repository == 'team-telnyx/telnyx-go'
+        run: go build ./...
   lint:
     timeout-minutes: 10
     name: lint

--- a/.github/workflows/release-pr-auto-merge.yml
+++ b/.github/workflows/release-pr-auto-merge.yml
@@ -46,8 +46,10 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
+        github.event.pull_request.state == 'open' &&
         startsWith(github.event.pull_request.head.ref, 'release-please--') &&
-        startsWith(github.event.pull_request.title, 'release: ')
+        startsWith(github.event.pull_request.title, 'release: ') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'autorelease: pending')
       )
     runs-on: ubuntu-latest
     timeout-minutes: 65


### PR DESCRIPTION
## Summary
- run a real GitHub-hosted `go build ./...` for Release Please PRs
- preserve Stainless upstream build behavior in all other contexts
- run the privileged gate only for open Release Please PRs and the `autorelease: pending` label

## Why
The exact-head gate correctly rejects skipped required checks, but the production `build` job was always skipped outside `stainless-sdks/telnyx-go`. Post-release `autorelease: tagged` labels also produced noisy failed gate runs against already-merged PRs.

## Validation
- 24/24 behavior tests
- `actionlint .github/workflows/ci.yml`
- `actionlint .github/workflows/release-pr-auto-merge.yml`
- `git diff --check`