### PR TITLE
fix(ci): dispatch Go release gate explicitly

### DIFF
--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -385,6 +385,8 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertIn(
             "github.event.label.name == 'autorelease: pending'", workflow
         )
+        self.assertIn("  policy-test:\n", workflow)
+        self.assertNotIn("\n  test:\n", workflow)
 
     def test_merge_uses_immediate_rest_put_and_never_enables_auto_merge(self):
         client = GitHubClient(GateConfig.python(), "test-token")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -268,7 +268,7 @@ jobs:
             exit 0
           fi
           open_prs=0
-          for attempt in 1 2 3; do
+          for _attempt in 1 2 3; do
             open_prs=$(gh pr list --repo "$REPO" --state open --json headRefName \
               --jq '[.[] | select(.headRefName | startswith("release-please--"))] | length')
             [ "$open_prs" -gt 0 ] && break
@@ -279,6 +279,28 @@ jobs:
             exit 1
           fi
           echo "Release PR present for unreleased commits — OK."
+
+      - name: Dispatch exact-head release PR gate
+        if: github.ref == 'refs/heads/next'
+        env:
+          GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mapfile -t release_prs < <(
+            gh pr list --repo "$REPO" --state open --json number,headRefName \
+              --jq '.[] | select(.headRefName | startswith("release-please--")) | .number'
+          )
+          if [ "${#release_prs[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one open Release Please PR before gate dispatch; found ${#release_prs[@]}"
+            exit 1
+          fi
+          gh workflow run release-pr-auto-merge.yml \
+            --repo "$REPO" \
+            --ref main \
+            -f pr_number="${release_prs[0]}" \
+            -f dry_run=false
+          echo "Dispatched exact-head gate for PR #${release_prs[0]}"
 
       - name: Run release-please (github-release)
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/release-pr-auto-merge.yml
+++ b/.github/workflows/release-pr-auto-merge.yml
@@ -30,7 +30,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  policy-test:
+    name: policy-test
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary
- after `next` proves exactly one generated Release Please PR exists, dispatch the trusted default-branch exact-head gate
- fail closed on missing or ambiguous generated release PRs
- retain all exact-head, provenance, checks, tree, ruleset, and merge re-attestation inside the gate

## Why
Two real Release Please synchronizations updated #185 without emitting a `pull_request_target` event in this repository. Explicit trusted dispatch makes the Go path deterministic instead of depending on that event.

## Validation
- `actionlint .github/workflows/release-please.yml`
- `git diff --check`