### PR TITLE
fix(ci): preserve release title in squash

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -171,6 +171,7 @@ class Attestation:
     head_sha: str
     base_sha: str
     next_sha: str
+    title: str
     version: str
     staging_sha: str
     config_sha: str
@@ -217,7 +218,7 @@ class ReleasePRAutoMergeGate:
         if dry_run:
             return {"status": "ready", "head_sha": first.head_sha, "dry_run": True}
 
-        self.client.merge(pr_number, first.head_sha)
+        self.client.merge(pr_number, first.head_sha, first.title)
         merged = self.client.read_merge_result(pr_number)
         merge_sha = merged.get("merge_commit_sha")
         if (
@@ -293,7 +294,15 @@ class ReleasePRAutoMergeGate:
         self._attest_tree(snapshot)
         staging_sha, config_sha = self._attest_provenance(snapshot, version)
         self._attest_checks(snapshot, head_sha)
-        return Attestation(head_sha, default_sha, next_sha, version, staging_sha, config_sha)
+        return Attestation(
+            head_sha,
+            default_sha,
+            next_sha,
+            "release: %s" % version,
+            version,
+            staging_sha,
+            config_sha,
+        )
 
     def _attest_tree(self, snapshot: Mapping[str, Any]) -> None:
         head_tree = self._tree(snapshot.get("head_tree"), "PR head tree")
@@ -711,7 +720,7 @@ class GitHubClient:
                     raise GateError("invalid required-status context")
         return sorted(contexts)
 
-    def merge(self, pr_number: int, expected_head: str) -> None:
+    def merge(self, pr_number: int, expected_head: str, commit_title: str) -> None:
         merge_token = os.environ.get("MERGE_TOKEN")
         if not merge_token:
             raise GateError("MERGE_TOKEN is required for live merge")
@@ -731,6 +740,8 @@ class GitHubClient:
             "merge_method=squash",
             "--raw-field",
             "sha=%s" % expected_head,
+            "--raw-field",
+            "commit_title=%s" % commit_title,
         ]
         completed = subprocess.run(command, env=env, text=True, capture_output=True)
         if completed.returncode != 0:

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -119,8 +119,8 @@ class FixtureClient:
     def read_snapshot(self, _pr_number):
         return copy.deepcopy(self.snapshot)
 
-    def merge(self, pr_number, expected_head):
-        self.merge_calls.append((pr_number, expected_head))
+    def merge(self, pr_number, expected_head, commit_title):
+        self.merge_calls.append((pr_number, expected_head, commit_title))
 
     def read_merge_result(self, _pr_number):
         return copy.deepcopy(self.merge_result)
@@ -325,7 +325,7 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
     def test_live_mode_merges_only_the_attested_exact_head(self):
         client = FixtureClient()
         result = self.gate(client).run(415, HEAD, False)
-        self.assertEqual(client.merge_calls, [(415, HEAD)])
+        self.assertEqual(client.merge_calls, [(415, HEAD, "release: 4.174.0")])
         self.assertEqual(result["status"], "merged")
         self.assertEqual(result["merge_commit_sha"], MERGE)
 
@@ -398,7 +398,7 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         with mock.patch.dict("os.environ", {"MERGE_TOKEN": "test-token"}), mock.patch(
             "release_pr_auto_merge.subprocess.run", return_value=completed
         ) as run:
-            client.merge(415, HEAD)
+            client.merge(415, HEAD, "release: 4.174.0")
 
         command = run.call_args.args[0]
         self.assertEqual(
@@ -408,6 +408,7 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertIn("PUT", command)
         self.assertIn("merge_method=squash", command)
         self.assertIn("sha=%s" % HEAD, command)
+        self.assertIn("commit_title=release: 4.174.0", command)
         self.assertNotIn("pr", command)
 
 


### PR DESCRIPTION
## Summary
- pass the fully attested Release Please PR title to the immediate REST squash merge
- keep release commits machine-recognizable as `release: X.Y.Z`
- add regression coverage for the exact merge payload

## Validation
- 24 policy tests pass
- Python compilation passes
- `git diff --check` passes

Follow-up from hosted Go v4.93.0 validation: the tag/release succeeded, but the default REST squash title inherited `chore: sync code...`, causing the provenance-compatible CLI dispatch guard to skip.