### PR TITLE
fix: sync Go lifecycle guards to next

### DIFF
--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -28,6 +28,8 @@ class ReleasePRGateWorkflowTests(unittest.TestCase):
         self.assertIn("verify_go_release.py", workflow)
         self.assertIn('--version "$VERSION"', workflow)
         self.assertIn('--release-sha "$RELEASE_SHA"', workflow)
+        self.assertNotIn("release-pr-auto-merge.yml", workflow)
+        self.assertNotIn("Dispatch exact-head release PR gate", workflow)
 
     def test_next_readiness_is_lightweight_and_fail_closed(self):
         workflow = (ROOT / ".github/workflows/next-readiness.yml").read_text()

--- a/.github/scripts/test_validate_next_provenance.py
+++ b/.github/scripts/test_validate_next_provenance.py
@@ -5,6 +5,7 @@ import unittest
 from release_pr_auto_merge import GateError
 from validate_next_provenance import (
     PRODUCTION_POLICY_PATHS,
+    PROMOTION_TRANSFORM_PATHS,
     api_tree,
     changed_paths,
     require_policy_parity,
@@ -30,6 +31,15 @@ class GoNextProvenanceTests(unittest.TestCase):
             {"src/generated.go": A, "go.mod": A},
             {"src/generated.go": A, "go.mod": B},
             {"go.mod"},
+            "promotion",
+        )
+
+    def test_production_owned_codeowners_is_an_allowed_promotion_transform(self):
+        self.assertIn(".github/CODEOWNERS", PROMOTION_TRANSFORM_PATHS)
+        require_only_allowed_changes(
+            {".github/CODEOWNERS": A},
+            {".github/CODEOWNERS": B},
+            PROMOTION_TRANSFORM_PATHS,
             "promotion",
         )
 

--- a/.github/scripts/validate_next_provenance.py
+++ b/.github/scripts/validate_next_provenance.py
@@ -59,6 +59,7 @@ STAGING_ONLY_PATHS = frozenset(
 # Go promotion restores these production-maintained custom/dependency paths.
 PROMOTION_TRANSFORM_PATHS = frozenset(
     {
+        ".github/CODEOWNERS",
         "go.mod", "go.sum",
         "lib/webhook_verification.go", "lib/webhook_verification_test.go",
         "lib/websocket.go", "lib/speech_to_text_ws.go",

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -280,28 +280,6 @@ jobs:
           fi
           echo "Release PR present for unreleased commits — OK."
 
-      - name: Dispatch exact-head release PR gate
-        if: github.ref == 'refs/heads/next'
-        env:
-          GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          mapfile -t release_prs < <(
-            gh pr list --repo "$REPO" --state open --json number,headRefName \
-              --jq '.[] | select(.headRefName | startswith("release-please--")) | .number'
-          )
-          if [ "${#release_prs[@]}" -ne 1 ]; then
-            echo "::error::Expected exactly one open Release Please PR before gate dispatch; found ${#release_prs[@]}"
-            exit 1
-          fi
-          gh workflow run release-pr-auto-merge.yml \
-            --repo "$REPO" \
-            --ref main \
-            -f pr_number="${release_prs[0]}" \
-            -f dry_run=false
-          echo "Dispatched exact-head gate for PR #${release_prs[0]}"
-
       - name: Run release-please (github-release)
         if: github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
## Summary
- allow the explicit production-owned CODEOWNERS promotion transform
- remove dispatch to the disabled legacy release auto-merge workflow
- keep next policy identical to the validated default branch

## Validation
- release gate regression suite
- next provenance regression suite
- workflow YAML parse
- git diff --check

Hosted next provenance will be revalidated against the immutable merge SHA after this PR lands.