### PR TITLE
ci: retry and observe CLI release handoffs

### DIFF
--- a/.github/scripts/dispatch_cli_release.py
+++ b/.github/scripts/dispatch_cli_release.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Deliver an immutable Go release handoff and prove the CLI run was created."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import uuid
+from typing import Callable, NamedTuple
+
+CLI_REPOSITORY = "team-telnyx/telnyx-cli-staging"
+CLI_WORKFLOW = "promote-to-prod.yml"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(r"^v4\.[0-9]+\.[0-9]+$")
+HANDOFF_RE = re.compile(r"^[0-9a-z-]{8,80}$")
+
+
+class HandoffError(RuntimeError):
+    """The handoff could not be delivered or independently observed."""
+
+
+class HandoffResult(NamedTuple):
+    mode: str
+    run_id: int
+    run_url: str
+    handoff_id: str
+
+
+def validate_payload(payload):
+    required = {"handoff_id", "go_version", "go_release_sha", "sdk_config_sha"}
+    if set(payload) != required:
+        raise HandoffError("handoff payload has missing or unknown fields")
+    if not HANDOFF_RE.fullmatch(payload["handoff_id"]):
+        raise HandoffError("handoff_id is malformed")
+    if not VERSION_RE.fullmatch(payload["go_version"]):
+        raise HandoffError("go_version must be an exact v4.X.Y tag")
+    for key in ("go_release_sha", "sdk_config_sha"):
+        if not SHA_RE.fullmatch(payload[key]):
+            raise HandoffError(f"{key} must be a full lowercase commit SHA")
+
+
+def _attempt(operation: Callable[[], None], attempts: int, sleep: Callable[[float], None]):
+    errors = []
+    for attempt in range(1, attempts + 1):
+        try:
+            operation()
+            return errors
+        except HandoffError as error:
+            errors.append(str(error))
+            if attempt < attempts:
+                sleep(min(2 ** (attempt - 1), 8))
+    raise HandoffError("; ".join(errors))
+
+
+def _observe(client, handoff_id, attempts, sleep):
+    marker = f"[handoff:{handoff_id}]"
+    for attempt in range(attempts):
+        candidates = [
+            run
+            for run in client.list_workflow_runs()
+            if run.get("event") in {"repository_dispatch", "workflow_dispatch"}
+            and marker in (run.get("display_title") or "")
+        ]
+        if len(candidates) > 1:
+            raise HandoffError(f"multiple CLI workflow runs claim handoff {handoff_id}")
+        if candidates:
+            run = candidates[0]
+            run_id = run.get("id")
+            run_url = run.get("html_url")
+            if not isinstance(run_id, int) or not isinstance(run_url, str):
+                raise HandoffError("observed CLI workflow run has malformed identity")
+            return run_id, run_url
+        if attempt + 1 < attempts:
+            sleep(10)
+    return None
+
+
+def deliver_and_observe(
+    client,
+    payload,
+    *,
+    dispatch_attempts=3,
+    observation_attempts=30,
+    sleep=time.sleep,
+):
+    validate_payload(payload)
+    if dispatch_attempts < 1 or observation_attempts < 1:
+        raise HandoffError("attempt counts must be positive")
+
+    envelope = {"event_type": "telnyx-go-released", "client_payload": dict(payload)}
+    mode = "repository_dispatch"
+    try:
+        _attempt(lambda: client.dispatch_repository(envelope), dispatch_attempts, sleep)
+    except HandoffError as primary_error:
+        mode = "workflow_dispatch"
+        try:
+            _attempt(lambda: client.dispatch_workflow(dict(payload)), dispatch_attempts, sleep)
+        except HandoffError as fallback_error:
+            raise HandoffError(
+                "CLI handoff could not be delivered by repository or workflow dispatch: "
+                f"repository={primary_error}; workflow={fallback_error}"
+            ) from fallback_error
+
+    primary_observation_attempts = min(observation_attempts, 6)
+    observed = _observe(client, payload["handoff_id"], primary_observation_attempts, sleep)
+    if observed is None and mode == "repository_dispatch":
+        # A 204 without an observable run is not proof of delivery. Immediately
+        # reconcile through the independently addressable workflow endpoint.
+        mode = "workflow_dispatch"
+        _attempt(lambda: client.dispatch_workflow(dict(payload)), dispatch_attempts, sleep)
+        observed = _observe(client, payload["handoff_id"], observation_attempts, sleep)
+    if observed is None:
+        raise HandoffError(
+            f"CLI handoff {payload['handoff_id']} was dispatched but no exact workflow run was observable"
+        )
+    return HandoffResult(mode, observed[0], observed[1], payload["handoff_id"])
+
+
+class GhClient:
+    def __init__(self, repository=CLI_REPOSITORY, workflow=CLI_WORKFLOW):
+        self.repository = repository
+        self.workflow = workflow
+
+    def _api(self, method, path, payload=None):
+        command = ["gh", "api", "--method", method, path]
+        if payload is not None:
+            command.extend(("--input", "-"))
+        process = subprocess.run(
+            command,
+            input=(json.dumps(payload) if payload is not None else None),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if process.returncode != 0:
+            detail = process.stderr.strip() or process.stdout.strip()
+            raise HandoffError(f"GitHub API {method} {path} failed: {detail}")
+        if not process.stdout.strip():
+            return None
+        try:
+            return json.loads(process.stdout)
+        except json.JSONDecodeError as error:
+            raise HandoffError(f"GitHub API returned malformed JSON for {path}") from error
+
+    def dispatch_repository(self, payload):
+        self._api("POST", f"repos/{self.repository}/dispatches", payload)
+
+    def dispatch_workflow(self, inputs):
+        self._api(
+            "POST",
+            f"repos/{self.repository}/actions/workflows/{self.workflow}/dispatches",
+            {"ref": "main", "inputs": inputs},
+        )
+
+    def list_workflow_runs(self):
+        response = self._api(
+            "GET",
+            f"repos/{self.repository}/actions/workflows/{self.workflow}/runs?per_page=30",
+        )
+        runs = response.get("workflow_runs") if isinstance(response, dict) else None
+        if not isinstance(runs, list):
+            raise HandoffError("GitHub API did not return a workflow run list")
+        return runs
+
+
+def _write_output(path, result):
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"handoff_id={result.handoff_id}\n")
+        handle.write(f"cli_run_id={result.run_id}\n")
+        handle.write(f"cli_run_url={result.run_url}\n")
+        handle.write(f"delivery_mode={result.mode}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--go-version", required=True)
+    parser.add_argument("--go-release-sha", required=True)
+    parser.add_argument("--sdk-config-sha", required=True)
+    parser.add_argument("--handoff-id", default=f"go-{uuid.uuid4().hex}")
+    parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT"))
+    args = parser.parse_args()
+    payload = {
+        "handoff_id": args.handoff_id,
+        "go_version": args.go_version,
+        "go_release_sha": args.go_release_sha,
+        "sdk_config_sha": args.sdk_config_sha,
+    }
+    try:
+        result = deliver_and_observe(GhClient(), payload)
+    except HandoffError as error:
+        parser.error(str(error))
+    _write_output(args.github_output, result)
+    print(json.dumps(result._asdict(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_dispatch_cli_release.py
+++ b/.github/scripts/test_dispatch_cli_release.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Tests for durable and observable Go-to-CLI release handoff."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+SCRIPT = Path(__file__).with_name("dispatch_cli_release.py")
+SPEC = importlib.util.spec_from_file_location("dispatch_cli_release", SCRIPT)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+try:
+    SPEC.loader.exec_module(module)
+except FileNotFoundError:
+    module = None
+
+
+class FakeClient:
+    def __init__(self, repository_failures=0, workflow_failures=0, runs=None):
+        self.repository_failures = repository_failures
+        self.workflow_failures = workflow_failures
+        self.runs = list(runs or [])
+        self.repository_payloads = []
+        self.workflow_inputs = []
+        self.list_calls = 0
+
+    def dispatch_repository(self, payload):
+        self.repository_payloads.append(payload)
+        if self.repository_failures:
+            self.repository_failures -= 1
+            raise module.HandoffError("transient repository dispatch failure")
+
+    def dispatch_workflow(self, inputs):
+        self.workflow_inputs.append(inputs)
+        if self.workflow_failures:
+            self.workflow_failures -= 1
+            raise module.HandoffError("transient workflow dispatch failure")
+
+    def list_workflow_runs(self):
+        self.list_calls += 1
+        return self.runs
+
+
+def run(handoff_id="handoff-123", **client_kwargs):
+    client = FakeClient(**client_kwargs)
+    payload = {
+        "handoff_id": handoff_id,
+        "go_version": "v4.97.0",
+        "go_release_sha": "1" * 40,
+        "sdk_config_sha": "2" * 40,
+    }
+    result = module.deliver_and_observe(
+        client,
+        payload,
+        dispatch_attempts=3,
+        observation_attempts=2,
+        sleep=lambda _: None,
+    )
+    return client, result
+
+
+@unittest.skipIf(module is None, "implementation does not exist yet")
+class DispatchCliReleaseTests(unittest.TestCase):
+    def test_repository_dispatch_is_immediate_and_exact(self):
+        run_record = {
+            "id": 77,
+            "event": "repository_dispatch",
+            "display_title": "Promote CLI [handoff:handoff-123]",
+            "html_url": "https://github.example/runs/77",
+        }
+        client, result = run(runs=[run_record])
+        self.assertEqual(result.mode, "repository_dispatch")
+        self.assertEqual(result.run_id, 77)
+        self.assertEqual(client.repository_payloads[0]["client_payload"]["go_version"], "v4.97.0")
+        self.assertEqual(client.repository_payloads[0]["client_payload"]["sdk_config_sha"], "2" * 40)
+        self.assertEqual(client.workflow_inputs, [])
+
+    def test_retries_recoverable_repository_delivery(self):
+        record = {
+            "id": 78,
+            "event": "repository_dispatch",
+            "display_title": "Promote CLI [handoff:handoff-123]",
+            "html_url": "https://github.example/runs/78",
+        }
+        client, result = run(repository_failures=2, runs=[record])
+        self.assertEqual(len(client.repository_payloads), 3)
+        self.assertEqual(result.run_id, 78)
+
+    def test_immediate_workflow_reconciliation_after_delivery_failure(self):
+        record = {
+            "id": 79,
+            "event": "workflow_dispatch",
+            "display_title": "Promote CLI [handoff:handoff-123]",
+            "html_url": "https://github.example/runs/79",
+        }
+        client, result = run(repository_failures=3, runs=[record])
+        self.assertEqual(result.mode, "workflow_dispatch")
+        self.assertEqual(client.workflow_inputs[0]["handoff_id"], "handoff-123")
+        self.assertEqual(client.workflow_inputs[0]["go_release_sha"], "1" * 40)
+
+    def test_unobserved_primary_delivery_triggers_immediate_reconciliation(self):
+        client = FakeClient(runs=[])
+        payload = {
+            "handoff_id": "handoff-456",
+            "go_version": "v4.97.0",
+            "go_release_sha": "1" * 40,
+            "sdk_config_sha": "2" * 40,
+        }
+
+        original_dispatch_workflow = client.dispatch_workflow
+
+        def dispatch_workflow(inputs):
+            original_dispatch_workflow(inputs)
+            client.runs = [{
+                "id": 80,
+                "event": "workflow_dispatch",
+                "display_title": "Promote CLI [handoff:handoff-456]",
+                "html_url": "https://github.example/runs/80",
+            }]
+
+        client.dispatch_workflow = dispatch_workflow
+        result = module.deliver_and_observe(
+            client, payload, dispatch_attempts=1, observation_attempts=1, sleep=lambda _: None
+        )
+        self.assertEqual(result.mode, "workflow_dispatch")
+        self.assertEqual(result.run_id, 80)
+
+    def test_fails_loud_when_neither_delivery_path_is_observable(self):
+        client = FakeClient(repository_failures=2, workflow_failures=2)
+        payload = {
+            "handoff_id": "handoff-789",
+            "go_version": "v4.97.0",
+            "go_release_sha": "1" * 40,
+            "sdk_config_sha": "2" * 40,
+        }
+        with self.assertRaisesRegex(module.HandoffError, "could not be delivered"):
+            module.deliver_and_observe(
+                client, payload, dispatch_attempts=2, observation_attempts=1, sleep=lambda _: None
+            )
+
+    def test_observation_requires_exact_handoff_identity(self):
+        wrong = {
+            "id": 81,
+            "event": "repository_dispatch",
+            "display_title": "Promote CLI [handoff:other]",
+            "html_url": "https://github.example/runs/81",
+        }
+        client = FakeClient(workflow_failures=1, runs=[wrong])
+        payload = {
+            "handoff_id": "wanted",
+            "go_version": "v4.97.0",
+            "go_release_sha": "1" * 40,
+            "sdk_config_sha": "2" * 40,
+        }
+        with self.assertRaises(module.HandoffError):
+            module.deliver_and_observe(
+                client, payload, dispatch_attempts=1, observation_attempts=1, sleep=lambda _: None
+            )
+
+
+if __name__ == "__main__":
+    if module is None:
+        raise SystemExit("dispatch_cli_release.py is missing (expected red test state)")
+    unittest.main()

--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -18,9 +18,16 @@ class ReleasePRGateWorkflowTests(unittest.TestCase):
         for test in (
             "test_release_pr_auto_merge.py", "test_release_pr_ci_gate.py",
             "test_classify_production_ci.py", "test_validate_next_provenance.py",
-            "test_verify_go_release.py",
+            "test_verify_go_release.py", "test_dispatch_cli_release.py",
         ):
             self.assertIn(test, ci)
+
+    def test_release_workflow_handoff_is_retried_and_observed(self):
+        workflow = (ROOT / ".github/workflows/release-please.yml").read_text()
+        self.assertIn("id: cli-handoff", workflow)
+        self.assertIn("dispatch_cli_release.py", workflow)
+        self.assertIn('--sdk-config-sha "$SDK_CONFIG_SHA"', workflow)
+        self.assertIn("steps.cli-handoff.outputs.cli_run_url", workflow)
 
     def test_release_workflow_verifies_tag_and_module_after_release(self):
         workflow = (ROOT / ".github/workflows/release-please.yml").read_text()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           python3 .github/scripts/test_classify_production_ci.py -v
           python3 .github/scripts/test_validate_next_provenance.py -v
           python3 .github/scripts/test_verify_go_release.py -v
+          python3 .github/scripts/test_dispatch_cli_release.py -v
   test:
     needs: classify-production-ci
     timeout-minutes: 10

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -371,6 +371,7 @@ jobs:
             --release-sha "$RELEASE_SHA"
 
       - name: Dispatch compatible release to CLI promotion
+        id: cli-handoff
         if: github.ref == 'refs/heads/main' && steps.release.outputs.is_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
@@ -448,21 +449,23 @@ jobs:
             exit 1
           fi
 
-          jq -n \
-            --arg version "v$VERSION" \
-            --arg release_sha "$RELEASE_SHA" \
-            --arg sdk_config_sha "$SDK_CONFIG_SHA" \
-            '{
-              event_type: "telnyx-go-released",
-              client_payload: {
-                go_version: $version,
-                go_release_sha: $release_sha,
-                sdk_config_sha: $sdk_config_sha
-              }
-            }' \
-            | gh api \
-                repos/team-telnyx/telnyx-cli-staging/dispatches \
-                --method POST \
-                --input -
+          python3 .github/scripts/dispatch_cli_release.py \
+            --go-version "v$VERSION" \
+            --go-release-sha "$RELEASE_SHA" \
+            --sdk-config-sha "$SDK_CONFIG_SHA" \
+            --github-output "$GITHUB_OUTPUT"
 
-          echo "Dispatched v$VERSION from SDK config $SDK_CONFIG_SHA to CLI promotion"
+      - name: Record observable CLI handoff
+        if: github.ref == 'refs/heads/main' && steps.release.outputs.is_release == 'true'
+        env:
+          HANDOFF_ID: ${{ steps.cli-handoff.outputs.handoff_id }}
+          DELIVERY_MODE: ${{ steps.cli-handoff.outputs.delivery_mode }}
+          CLI_RUN_ID: ${{ steps.cli-handoff.outputs.cli_run_id }}
+          CLI_RUN_URL: ${{ steps.cli-handoff.outputs.cli_run_url }}
+        run: |
+          {
+            echo "### Go → CLI release handoff"
+            echo "- Handoff: \`$HANDOFF_ID\`"
+            echo "- Delivery: \`$DELIVERY_MODE\`"
+            echo "- CLI run: [$CLI_RUN_ID]($CLI_RUN_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- retry immutable Go-to-CLI repository dispatches after verified publication
- immediately fall back to exact workflow dispatch when delivery fails or no run is observable
- correlate and surface the exact CLI promotion run URL in the Go release summary

## Validation
- all Go release-policy tests pass
- workflow YAML parses and actionlint passes

Depends on team-telnyx/telnyx-cli-staging#224
Linear: DOT-2065