### PR TITLE
fix: attest Go CLI release handoff policy

### DIFF
--- a/.github/scripts/test_validate_next_provenance.py
+++ b/.github/scripts/test_validate_next_provenance.py
@@ -43,6 +43,19 @@ class GoNextProvenanceTests(unittest.TestCase):
             "promotion",
         )
 
+    def test_cli_release_handoff_scripts_are_fail_closed_production_policy(self):
+        paths = {
+            ".github/scripts/dispatch_cli_release.py",
+            ".github/scripts/test_dispatch_cli_release.py",
+        }
+        self.assertTrue(paths <= PRODUCTION_POLICY_PATHS)
+        with self.assertRaisesRegex(GateError, "dispatch_cli_release.py"):
+            require_policy_parity(
+                {path: A for path in paths},
+                {path: B for path in paths},
+                paths,
+            )
+
     def test_add_delete_and_modify_are_all_detected(self):
         self.assertEqual(
             changed_paths({"same": A, "deleted": A, "changed": A}, {"same": A, "added": B, "changed": B}),

--- a/.github/scripts/validate_next_provenance.py
+++ b/.github/scripts/validate_next_provenance.py
@@ -29,8 +29,10 @@ TreeEntry = Tuple[str, str, str]
 PRODUCTION_POLICY_PATHS = frozenset(
     {
         ".github/scripts/classify_production_ci.py",
+        ".github/scripts/dispatch_cli_release.py",
         ".github/scripts/release_pr_auto_merge.py",
         ".github/scripts/test_classify_production_ci.py",
+        ".github/scripts/test_dispatch_cli_release.py",
         ".github/scripts/test_release_pr_auto_merge.py",
         ".github/scripts/test_release_pr_ci_gate.py",
         ".github/scripts/test_validate_next_provenance.py",


### PR DESCRIPTION
## Summary

- classify the Go CLI release dispatch script and its policy test as production-owned release policy
- require exact parity for both paths between production `main` and promoted `next`
- add a regression proving both paths are in the fail-closed policy inventory

## Root cause

The durable staging fix in `team-telnyx/telnyx-go-staging#279` correctly restored these production-owned files during promotion:

- `.github/scripts/dispatch_cli_release.py`
- `.github/scripts/test_dispatch_cli_release.py`

The first live promotion preserved them on `next`, but the protected `next-readiness` validator rejected the restoration because its production-policy inventory had not yet classified those paths as allowed production-owned changes:

`staging-to-promotion tree changed non-allowed paths: .github/scripts/dispatch_cli_release.py, .github/scripts/test_dispatch_cli_release.py`

Failed lifecycle proof: https://github.com/team-telnyx/telnyx-go/actions/runs/33048707489

These are release-control policy files, so they belong in `PRODUCTION_POLICY_PATHS`, not the broader transform-only inventory. This both permits their intentional restoration and requires `next` to match `main` byte-for-byte.

## What is done

- Staging-to-promotion restoration of both paths is explicitly allowed.
- Post-promotion `next` is permitted to contain the production-owned versions.
- `require_policy_parity` fails closed if either file is missing from or differs from production `main`.

**Not done if:** the validator merely ignores these files without enforcing exact default-branch parity.

## Verification

- New regression observed failing before implementation and passing afterward.
- Production release-policy tests: 63 passed across six suites.
- Python compilation: passed.
- `git diff --check`: passed.

## Companion

- Staging preservation mechanism: https://github.com/team-telnyx/telnyx-go-staging/pull/279
- Live generated promotion: https://github.com/team-telnyx/telnyx-go-staging/pull/280
- Refreshed release PR: https://github.com/team-telnyx/telnyx-go/pull/204
