### PR TITLE
fix: treat skipped check runs as non-attesting in the release gate

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -412,6 +412,11 @@ class ReleasePRAutoMergeGate:
                 and check.get("head_sha") == head_sha
                 and isinstance(check.get("app"), Mapping)
                 and check["app"].get("slug") == app
+                # Classify-skip CI runs publish same-named skipped check runs
+                # on the exact head before the attesting run starts. A skip
+                # carries no verdict: keep waiting for a real run instead of
+                # failing closed on the race.
+                and check.get("conclusion") != "skipped"
             ]
             successes = [
                 check

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -283,6 +283,39 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         result = self.gate(client).run(415, HEAD, True)
         self.assertEqual(result["status"], "ready")
 
+    def test_skipped_only_required_check_waits_instead_of_failing_closed(self):
+        client = FixtureClient()
+        build = next(c for c in client.snapshot["checks"] if c["name"] == "build")
+        build.update(conclusion="skipped")
+        self.assert_blocked(client, "timed out")
+
+    def test_skipped_run_is_superseded_by_successful_run_on_same_head(self):
+        client = FixtureClient()
+        skipped = copy.deepcopy(next(c for c in client.snapshot["checks"] if c["name"] == "build"))
+        skipped.update(id=999, conclusion="skipped", completed_at="2026-08-16T00:01:00Z")
+        client.snapshot["checks"].append(skipped)
+        result = self.gate(client).run(415, HEAD, True)
+        self.assertEqual(result["status"], "ready")
+
+    def test_skipped_check_becomes_successful_before_timeout(self):
+        raced = FixtureClient.good_snapshot()
+        next(c for c in raced["checks"] if c["name"] == "build").update(conclusion="skipped")
+        ready = FixtureClient.good_snapshot()
+        client = SequenceClient([raced, ready, ready])
+        sleeps = []
+        result = self.gate(client, attempts=2, sleeps=sleeps).run(415, HEAD, True)
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(sleeps, [0])
+
+    def test_skipped_run_does_not_mask_real_failure_on_same_head(self):
+        client = FixtureClient()
+        build = next(c for c in client.snapshot["checks"] if c["name"] == "build")
+        build.update(conclusion="skipped")
+        failed = copy.deepcopy(build)
+        failed.update(id=999, conclusion="failure", completed_at="2026-08-16T00:01:00Z")
+        client.snapshot["checks"].append(failed)
+        self.assert_blocked(client, "check failed: build")
+
     def test_success_from_wrong_app_does_not_satisfy_check(self):
         client = FixtureClient()
         build = next(c for c in client.snapshot["checks"] if c["name"] == "build")


### PR DESCRIPTION
## Summary

The `release-provenance` readiness gate fails closed on a benign timing race, observed on #204 (release: 4.98.0, head `c053321`):

1. A release-please push fires CI twice on the same head: a **push-event** run whose classify step skips `build`/`lint`/`test` (completed with conclusion `skipped` within ~10s), and a **pull_request-event** run that actually executes them (~70s later on #204).
2. The readiness workflow (`pull_request_target` on PR synchronize) attested in between. `_attest_checks` found exactly one `build` check run on the exact head — the skipped one — and treated completed-but-not-success as a terminal verdict: instant `GateError: required exact-head check failed: build`, no polling (the 120×30s poll loop only engages for pending/missing checks).
3. Seconds later the real CI passed on the same SHA, but nothing re-triggers the gate, so the stale failing `release-provenance` status blocks the release PR until someone re-dispatches the workflow.

This change excludes `conclusion == "skipped"` check runs from attestation candidates. A skip carries no verdict about the head, so the gate now classifies it as pending/missing and rides out the race in its existing poll loop. Fail-closed behavior is preserved: genuine failures still block immediately, and a head whose required checks never run still times out after the poll budget.

## Testing

- `python3 .github/scripts/test_release_pr_auto_merge.py -v` — 29 tests pass (4 new):
  - skipped-only required check → waits, then times out fail-closed (never an instant failure)
  - skipped run superseded by a successful run on the same head → ready
  - skipped run resolving to success across poll attempts (the #204 race) → ready
  - skipped run alongside a real failure on the same head → still blocks immediately
- All sibling gate suites pass unchanged: `test_release_pr_ci_gate`, `test_classify_production_ci`, `test_validate_next_provenance`, `test_verify_go_release`, `test_dispatch_cli_release`.
- `python3 -m py_compile` clean on both files.

## Not included

- No workflow changes. Side observation for a follow-up: `release-pr-auto-merge.yml` filters `pull_request`/`pull_request_target` on `branches: [master]`, which never matches this repo's `main` base — auto-merge has only ever run here via `workflow_dispatch`, and the `policy-test` job in that workflow never fires on PRs (the same tests do run via `ci.yml`'s lint job, which covers this PR).
- No fleet rollout: the same attestor pattern exists in telnyx-python/node/php/ruby/cli; the identical race applies wherever a classify-skip run shares check names with real CI. Happy to follow up per repo.
- #204 itself still needs its readiness workflow re-dispatched (or this fix merged first) to clear the stale status.