### PR TITLE
fix(ci): skip post-merge release readiness

### DIFF
--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -427,6 +427,27 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertIn("  policy-test:\n", workflow)
         self.assertNotIn("\n  test:\n", workflow)
 
+    def test_release_readiness_only_runs_for_open_pr_events(self):
+        with open(
+            ".github/workflows/release-pr-readiness.yml", encoding="utf-8"
+        ) as workflow_file:
+            workflow = workflow_file.read()
+
+        self.assertEqual(
+            sum(line == "  release-provenance:" for line in workflow.splitlines()), 1
+        )
+        self.assertIn(
+            "types: [opened, reopened, synchronize, ready_for_review]", workflow
+        )
+        self.assertNotIn("ready_for_review, labeled", workflow)
+        self.assertIn(
+            "  release-provenance:\n"
+            "    if: >-\n"
+            "      github.event_name == 'workflow_dispatch' ||\n"
+            "      github.event.pull_request.state == 'open'\n",
+            workflow,
+        )
+
     def test_merge_uses_immediate_rest_put_and_never_enables_auto_merge(self):
         client = GitHubClient(GateConfig.python(), "test-token")
         completed = mock.Mock(

--- a/.github/workflows/release-pr-readiness.yml
+++ b/.github/workflows/release-pr-readiness.yml
@@ -3,7 +3,7 @@ name: Exact-head release PR readiness
 on:
   pull_request_target:
     branches: [main]
-    types: [opened, reopened, synchronize, ready_for_review, labeled]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -28,9 +28,11 @@ concurrency:
 
 jobs:
   release-provenance:
-    name: release-provenance
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
-    timeout-minutes: 65
+
     env:
       EVENT_NAME: ${{ github.event_name }}
       EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- stop `pull_request_target: labeled` events from re-running open-PR readiness after Release Please merges
- gate `release-provenance` to manual dispatches or pull requests whose current event state is `open`
- add policy regression coverage for the trigger list, job guard, and single job definition

## Root cause

After a valid exact-head readiness run passes and the Release Please PR merges, Release Please adds `autorelease: tagged`. GitHub emits a `labeled` event for the already-closed PR. The readiness workflow previously treated that as a candidate and invoked the trusted attestor, which correctly rejected it with `not ready: PR is not open`. The resulting post-merge failure was attached to the same release head and obscured the applicable successful pre-merge attestation.

## Safety invariant

The trusted `.github/scripts/release_pr_auto_merge.py` attestor is unchanged and continues to fail closed if invoked against a non-open PR. This fix corrects event/candidate gating rather than weakening release authorization.

## Verification

- RED: new workflow-policy regression failed against the legacy `labeled` trigger and missing open-state guard
- GREEN: complete `.github/scripts/test_release_pr_auto_merge.py -v` suite passes
- `actionlint .github/workflows/release-pr-readiness.yml`
- PyYAML workflow parse
- `git diff --check`

## Scope

Only the production-owned readiness workflow and its policy tests are changed. The corresponding staging promotion restores this workflow from the production default branch, so later SDK generation will preserve the fix.
